### PR TITLE
Update Existing Pivot and SyncWithoutDetaching

### DIFF
--- a/src/Component/Ddd/Relationship/BelongsToMany.php
+++ b/src/Component/Ddd/Relationship/BelongsToMany.php
@@ -37,15 +37,6 @@ class BelongsToMany extends LaravelBelongsToMany
         );
     }
 
-    public function syncWithoutDetaching($ids)
-    {
-        $this->parent->addAfterAction(
-            function () use ($ids) {
-                parent::syncWithoutDetaching($ids);
-            }
-        );
-    }
-
     public function sync($ids, $detaching = true)
     {
         $this->parent->addAfterAction(

--- a/src/Component/Ddd/Relationship/BelongsToMany.php
+++ b/src/Component/Ddd/Relationship/BelongsToMany.php
@@ -63,4 +63,13 @@ class BelongsToMany extends LaravelBelongsToMany
             }
         );
     }
+
+    public function updateExistingPivot($id, array $attributes, $touch = true)
+    {
+        $this->parent->addAfterAction(
+            function () use ($id, $attributes) {
+                parent::updateExistingPivot($id, $attributes, $touch);
+            }
+        );
+    }
 }


### PR DESCRIPTION
1. add missing `updateExistingPivot($id, array $attributes, $touch = true)`

2. remove `syncWithoutDetaching($ids)`,
since laravel [method](https://github.com/laravel/framework/blob/5.5/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php#L70) has used its `sync($ids, false)`